### PR TITLE
予約された日記は表示されないように修正

### DIFF
--- a/backend/go/pkg/app/repository/repository.go
+++ b/backend/go/pkg/app/repository/repository.go
@@ -68,12 +68,13 @@ type TravelSpotDiaryRepository interface {
 	Update(ctx context.Context, travelSpotDiary *entity.TravelSpotDiary) error
 	FindByID(ctx context.Context, id entity.TravelSpotDiaryID) (*entity.TravelSpotDiary, error)
 	GetByIDs(ctx context.Context, ids []entity.TravelSpotDiaryID) (entity.TravelSpotDiaries, error)
-	FindByUserIDAndTravelSpotID(ctx context.Context, userID entity.UserID, travelSpotID entity.TravelSpotID) (*entity.TravelSpotDiary, error)
+	FindByUserIDAndTravelSpotID(ctx context.Context, userID entity.UserID, travelSpotID entity.TravelSpotID) (entity.TravelSpotDiaries, error)
 }
 
 type ReservationRepository interface {
 	Create(ctx context.Context, reservations ...entity.Reservation) error
 	FindByID(ctx context.Context, id entity.ReservationID) (*entity.Reservation, error)
+	FindByUserIDAndTravelSpotID(ctx context.Context, userID entity.UserID, travelSpotID entity.TravelSpotID) (entity.Reservations, error)
 	GetEndedReservations(ctx context.Context, userID entity.UserID) (entity.Reservations, error)
 	GetUpcomingReservations(ctx context.Context, userID entity.UserID) (entity.Reservations, error)
 }

--- a/backend/go/pkg/infrastructure/rdb/table/reservation_table.go
+++ b/backend/go/pkg/infrastructure/rdb/table/reservation_table.go
@@ -29,6 +29,17 @@ func (t *Reservation) FindByID(ctx context.Context, id entity.ReservationID) (*e
 	return res, nil
 }
 
+func (t *Reservation) FindByUserIDAndTravelSpotID(ctx context.Context, userID entity.UserID, travelSpotID entity.TravelSpotID) (entity.Reservations, error) {
+	res := entity.Reservations{}
+	if err := t.db.NewSelect().Model(&res).
+		Where("user_id = ?", userID).
+		Where("travel_spot_id = ?", travelSpotID).
+		Scan(ctx); err != nil {
+		return nil, handleError(err)
+	}
+	return res, nil
+}
+
 func (t *Reservation) GetEndedReservations(ctx context.Context, userID entity.UserID) (entity.Reservations, error) {
 	res := entity.Reservations{}
 	if err := t.db.NewSelect().Model(&res).

--- a/backend/go/pkg/infrastructure/rdb/table/travel_spot_diary_table.go
+++ b/backend/go/pkg/infrastructure/rdb/table/travel_spot_diary_table.go
@@ -46,9 +46,9 @@ func (t *TravelSpotDiary) GetByIDs(ctx context.Context, ids []entity.TravelSpotD
 	return res, nil
 }
 
-func (t *TravelSpotDiary) FindByUserIDAndTravelSpotID(ctx context.Context, userID entity.UserID, travelSpotID entity.TravelSpotID) (*entity.TravelSpotDiary, error) {
-	res := &entity.TravelSpotDiary{}
-	if err := t.db.NewSelect().Model(res).
+func (t *TravelSpotDiary) FindByUserIDAndTravelSpotID(ctx context.Context, userID entity.UserID, travelSpotID entity.TravelSpotID) (entity.TravelSpotDiaries, error) {
+	res := entity.TravelSpotDiaries{}
+	if err := t.db.NewSelect().Model(&res).
 		Where("user_id = ?", userID).
 		Where("travel_spot_id = ?", travelSpotID).
 		Scan(ctx); err != nil {


### PR DESCRIPTION
以下の不具合を修正しました。


### 不具合
```
やや影響範囲ある不具合です。
「ヒラマサを釣る体験」で予約(ヒラマサに限らず、何でも良い)
予約確認画面から、本文を更新する
1. で選択したものと同じ体験を再度予約しようとする
2. で行ったテキスト更新内容が反映された状態で表示されてしまう
```

### 修正方針
```
ログインユーザーが、すでに実行済みの体験は表示しない
```