### PR TITLE
体験一覧のoffer体験を塞ぐ対応

### DIFF
--- a/backend/go/pkg/app/usecase/travel_spot_usecase.go
+++ b/backend/go/pkg/app/usecase/travel_spot_usecase.go
@@ -45,6 +45,10 @@ func (u *TravelSpotUseCase) GetTravelSpots(ctx context.Context, userID entity.Us
 	// レベル3: 5回以上の体験したことがある
 	out := make(entity.TravelSpots, 0)
 	for _, travelSpot := range travelSpots {
+		// NOTE: オファー体験は表示しない
+		if travelSpot.Level == entity.TravelSpotForOffer {
+			continue
+		}
 		if (travelSpot.Level == entity.TravelSpotLevel1) ||
 			(travelSpot.Level == entity.TravelSpotLevel2 && len(rs) >= 3) ||
 			(travelSpot.Level == entity.TravelSpotLevel3 && len(rs) >= 5) {

--- a/backend/go/pkg/entity/travel_spot.go
+++ b/backend/go/pkg/entity/travel_spot.go
@@ -9,9 +9,10 @@ type TravelSpotID string
 type TravelSpotLevel int
 
 const (
-	TravelSpotLevel1 TravelSpotLevel = iota + 1
-	TravelSpotLevel2
-	TravelSpotLevel3
+	TravelSpotForOffer TravelSpotLevel = 0
+	TravelSpotLevel1   TravelSpotLevel = 1
+	TravelSpotLevel2   TravelSpotLevel = 2
+	TravelSpotLevel3   TravelSpotLevel = 3
 )
 
 type TravelSpot struct {


### PR DESCRIPTION
体験一覧でoffer体験が出てしまうので、レベル=0をoffer体験として除くように修正しました。